### PR TITLE
Bug/broken unit testing dependencies 20161003

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint": "1.4.3",
     "eslint-loader": "1.0.0",
     "eslint-plugin-react": "3.4.1",
-    "karma": "0.13.10",
+    "karma": "0.13.19",
     "karma-chai": "0.1.0",
     "karma-chai-plugins": "0.6.0",
     "karma-chai-sinon": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "karma-sinon-chai": "1.1.0",
     "karma-sourcemap-loader": "0.3.5",
     "karma-webpack": "1.7.0",
+    "mocha": "3.1.0",
     "react": "0.14.2",
     "react-addons-test-utils": "0.14.2",
     "react-dom": "0.14.2",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "karma-sourcemap-loader": "0.3.5",
     "karma-webpack": "1.7.0",
     "mocha": "3.1.0",
+    "phantomjs": "2.1.1",
+    "phantomjs-prebuilt": "2.1.4",
     "react": "0.14.2",
     "react-addons-test-utils": "0.14.2",
     "react-dom": "0.14.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:ci": "watch 'npm run test' src/"
   },
   "dependencies": {
-    "awesomplete": "1.0.0",
+    "awesomplete": "1.1.0",
     "promise-polyfill": "2.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "babel-cli": "6.1.18",
     "babel-core": "5.8.24",
-    "babel-eslint": "4.1.3",
+    "babel-eslint": "4.1.7",
     "babel-loader": "5.3.2",
     "babel-plugin-add-module-exports": "0.1.1",
     "babel-preset-es2015": "6.1.18",


### PR DESCRIPTION
Misc fixes to get `npm install` and `npm run test` commands working in local environment caused by broken dependencies.
