### PR TITLE
Update package.json to use a working version, current installs fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:ci": "watch 'npm run test' src/"
   },
   "dependencies": {
-    "awesomplete": "1.0.0",
+    "awesomplete": "1.1.0",
     "promise-polyfill": "2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
npm ERR! Linux 4.2.0-42-generic
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "install" "react-list-filter"
npm ERR! node v6.8.0
npm ERR! npm  v3.10.9
npm ERR! code ETARGET

npm ERR! notarget No compatible version found: awesomplete@1.0.0
npm ERR! notarget Valid install targets:
npm ERR! notarget 1.1.1, 1.1.0, 0.0.0
npm ERR! notarget 
npm ERR! notarget This is most likely not a problem with npm itself.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
npm ERR! notarget 
npm ERR! notarget It was specified as a dependency of 'react-list-filter'
npm ERR! notarget